### PR TITLE
Update steam-enhancement-pack.nsi

### DIFF
--- a/games/resident-evil-3-nemesis/steam-enhancement-pack.nsi
+++ b/games/resident-evil-3-nemesis/steam-enhancement-pack.nsi
@@ -381,16 +381,20 @@ SectionGroupEnd
 !endif
 
 Function .onSelChange
-    # Some graphics options are grouped together
-    ${If} ${SectionIsSelected} ${gfx1}
-    ${OrIf} ${SectionIsSelected} ${gfx2}
-    ${OrIf} ${SectionIsSelected} ${gfx3}
-        !insertmacro SelectSection ${gfx1}
+    # Graphics options are a dependency chain: gfx1 <- gfx2 <- gfx3
+    # Selecting a later layer force-selects its prerequisite(s).
+    ${If} ${SectionIsSelected} ${gfx3}
         !insertmacro SelectSection ${gfx2}
-        !insertmacro SelectSection ${gfx3}
-    ${Else}
-        !insertmacro UnselectSection ${gfx1}
+    ${EndIf}
+    ${If} ${SectionIsSelected} ${gfx2}
+        !insertmacro SelectSection ${gfx1}
+    ${EndIf}
+    # Deselecting an earlier layer force-deselects everything built on top of it.
+    ${IfNot} ${SectionIsSelected} ${gfx1}
         !insertmacro UnselectSection ${gfx2}
+        !insertmacro UnselectSection ${gfx3}
+    ${EndIf}
+    ${IfNot} ${SectionIsSelected} ${gfx2}
         !insertmacro UnselectSection ${gfx3}
     ${EndIf}
 


### PR DESCRIPTION
Allowed individual selection of graphic mods in the configurations 1, 1+2, or 1+2+3.
This does also affect `gog-enhancement-pack.nsi`.

**AI Disclosure:** AI was used in the making of this code change. Proceedings at [link](https://claude.ai/share/689310ed-2206-4543-bef7-611d91785b99). I've tested the change, confirmed it to have the intended effect (1+2), and to be playable.

Renaming autodeleted the previous PR.